### PR TITLE
Revert "get mapping working with namespaced APIs"

### DIFF
--- a/tastypie_swagger/mapping.py
+++ b/tastypie_swagger/mapping.py
@@ -107,16 +107,10 @@ class ResourceSwaggerMapping(object):
 
         We also use this to build the detail url, which may not be correct
         """
-        url_name = 'api_dispatch_list'
-        if self.resource._meta.urlconf_namespace:
-            url_name = '{}:{}'.format(
-                self.resource._meta.urlconf_namespace,
-                url_name
-            )
         if hasattr(self.resource, 'get_resource_list_uri'):
-            return self.resource.get_resource_list_uri(url_name=url_name)
+            return self.resource.get_resource_list_uri()
         elif hasattr(self.resource, 'get_resource_uri'):
-            return self.resource.get_resource_uri(url_name=url_name)
+            return self.resource.get_resource_uri()
         else:
             raise AttributeError('Resource %(resource)s has neither get_resource_list_uri nor get_resource_uri' % {'resource': self.resource})
 


### PR DESCRIPTION
@orcasgit/orcas-developers Please review. This reverts commit 5d8d0e2332847ca3200887496ccd29740f048356.

According to the docs (http://django-tastypie.readthedocs.io/en/latest/namespaces.html) to use a namespaced api, we also need to have each `Resource` inherit from `NamespacedModelResource`. Without that piece, when a new object is created via POST, the new object returned in the response will not have working url links for foreign keys. That is why tests are currently failing in screener https://circleci.com/gh/orcasgit/screener-app/138. The original commit was breaking paths for `NamespacedModelResource`s in the browsable swagger api. I think we can do this reversion, and then change the `mood` and `journal` apis to use `NamespacedModelResource`. 

